### PR TITLE
Fixed Name Validation

### DIFF
--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -1,11 +1,10 @@
-// <script type = "text/javascript">
 
        function validate() {
-        console.log("Validating...");
-          if(document.getElementById(name).value === "") {
+ 
+          if(document.getElementById("name").value === "") {
              alert("Please provide a name");
      //      document.input.name.focus();
-             document.getElementById(name).focus() ;
+             document.getElementById("name").focus() ;
              return false;
           }
 
@@ -57,5 +56,4 @@
           }
           return (true) ;
        }
-   //-->
- // </script>
+


### PR DESCRIPTION
In external script files, the script type is not needed.  To reference the elements, there needs to be double quotes around the field name.  I only fixed name.